### PR TITLE
fix: deprecate usage of mount()

### DIFF
--- a/packages/ui/__tests__/Alert.test.tsx
+++ b/packages/ui/__tests__/Alert.test.tsx
@@ -1,6 +1,8 @@
-import { mount } from 'enzyme'
 import { act } from 'react-dom/test-utils'
 import React from 'react'
+
+import { mountAndCheckA11Y } from '@hazelcast/test-helpers'
+
 import { AlertTriangle, CheckCircle, Info, Clipboard, AlertCircle } from 'react-feather'
 import { ToastType, IconDescriptor } from '../src/Toast'
 import { Alert, AlertActionButton, AlertActionLink } from '../src/Alert'
@@ -61,8 +63,8 @@ describe('Alert', () => {
 
   it.each(alertBasicTestData)(
     'Renders %s Alert with correct className, icon, title and content',
-    (type, { icon, ariaLabel }, className) => {
-      const wrapper = mount(<Alert type={type} title={title} content={content} closeToast={noOp} />)
+    async (type, { icon, ariaLabel }, className) => {
+      const wrapper = await mountAndCheckA11Y(<Alert type={type} title={title} content={content} closeToast={noOp} />)
 
       const AlertElement = wrapper.find(Alert)
 
@@ -80,10 +82,10 @@ describe('Alert', () => {
     },
   )
 
-  it('Close button calls closeToast prop handler', () => {
+  it('Close button calls closeToast prop handler', async () => {
     const closeToast = jest.fn()
 
-    const wrapper = mount(<Alert type="success" title={title} content={content} closeToast={closeToast} />)
+    const wrapper = await mountAndCheckA11Y(<Alert type="success" title={title} content={content} closeToast={closeToast} />)
 
     expect(closeToast).toHaveBeenCalledTimes(0)
 
@@ -100,8 +102,8 @@ describe('Alert', () => {
     ['2 actions', [AlertAction1, AlertAction2]],
   ]
 
-  it.each(alertActionsTestData)('Renders Alert with %s', (_, actions) => {
-    const wrapper = mount(<Alert type="success" title={title} content={content} closeToast={noOp} />)
+  it.each(alertActionsTestData)('Renders Alert with %s', async (_, actions) => {
+    const wrapper = await mountAndCheckA11Y(<Alert type="success" title={title} content={content} closeToast={noOp} />)
 
     wrapper
       .findDataTest('alert-actions')

--- a/packages/ui/__tests__/Button.test.tsx
+++ b/packages/ui/__tests__/Button.test.tsx
@@ -1,6 +1,8 @@
-import { mount } from 'enzyme'
 import React from 'react'
 import { X } from 'react-feather'
+
+import { mountAndCheckA11Y } from '@hazelcast/test-helpers'
+
 import { Button, ButtonKind } from '../src/Button'
 
 import styles from '../src/Button.module.scss'
@@ -15,30 +17,30 @@ describe('Button', () => {
     ['transparent', styles.transparent],
   ]
 
-  it.each(buttonKindTestData)('Renders Button with correct className which corresponds to button kind', (kind, className) => {
-    const wrapper = mount(<Button kind={kind}>Label</Button>)
+  it.each(buttonKindTestData)('Renders Button with correct className which corresponds to button kind', async (kind, className) => {
+    const wrapper = await mountAndCheckA11Y(<Button kind={kind}>Label</Button>)
 
     expect(wrapper.findDataTest('button').prop('className')).toMatch(`button ${className}`)
   })
 
   const labelTestData: [string][] = [['label'], [label], ['lAbEl']]
 
-  it.each(labelTestData)('Renders Button with correctly capitalized label, when capitalize=true: %s', (labelRaw) => {
-    const wrapper = mount(<Button>{labelRaw}</Button>)
+  it.each(labelTestData)('Renders Button with correctly capitalized label, when capitalize=true: %s', async (labelRaw) => {
+    const wrapper = await mountAndCheckA11Y(<Button>{labelRaw}</Button>)
 
     expect(wrapper.find(Button).text()).toBe(label)
   })
 
-  it('Renders Button with original label when capitalize=false', () => {
+  it('Renders Button with original label when capitalize=false', async () => {
     const label = 'label'
 
-    const wrapper = mount(<Button capitalize={false}>{label}</Button>)
+    const wrapper = await mountAndCheckA11Y(<Button capitalize={false}>{label}</Button>)
 
     expect(wrapper.find(Button).text()).toBe(label)
   })
 
-  it('Renders button with left icon with proper aria-label', () => {
-    const wrapper = mount(
+  it('Renders button with left icon with proper aria-label', async () => {
+    const wrapper = await mountAndCheckA11Y(
       <Button iconLeft={X} iconLeftAriaLabel={iconAriaLabel}>
         {label}
       </Button>,
@@ -56,8 +58,8 @@ describe('Button', () => {
     expect(wrapper.findDataTest('button-icon-right').exists()).toBeFalsy()
   })
 
-  it('Renders button with right icon with proper aria-label', () => {
-    const wrapper = mount(
+  it('Renders button with right icon with proper aria-label', async () => {
+    const wrapper = await mountAndCheckA11Y(
       <Button iconRight={X} iconRightAriaLabel="X Icon">
         {label}
       </Button>,
@@ -75,8 +77,8 @@ describe('Button', () => {
     })
   })
 
-  it('Renders button with left and right icons and proper aria-labels', () => {
-    const wrapper = mount(
+  it('Renders button with left and right icons and proper aria-labels', async () => {
+    const wrapper = await mountAndCheckA11Y(
       <Button iconLeft={X} iconLeftAriaLabel="X Icon" iconRight={X} iconRightAriaLabel="X Icon">
         {label}
       </Button>,

--- a/packages/ui/__tests__/Toast.test.tsx
+++ b/packages/ui/__tests__/Toast.test.tsx
@@ -1,6 +1,8 @@
-import { mount } from 'enzyme'
 import React from 'react'
 import { act } from 'react-dom/test-utils'
+
+import { mountAndCheckA11Y } from '@hazelcast/test-helpers'
+
 import { AlertTriangle, CheckCircle, Info, AlertCircle } from 'react-feather'
 import { Toast, ToastType, IconDescriptor } from '../src/Toast'
 
@@ -38,8 +40,8 @@ describe('Toast', () => {
     ],
   ]
 
-  it.each(toastBasicTestData)('Renders %s Toast with correct icon and content', (type, { icon, ariaLabel }) => {
-    const wrapper = mount(<Toast type={type} content={content} />)
+  it.each(toastBasicTestData)('Renders %s Toast with correct icon and content', async (type, { icon, ariaLabel }) => {
+    const wrapper = await mountAndCheckA11Y(<Toast type={type} content={content} />)
 
     const AlertElement = wrapper.find(Toast)
 
@@ -52,10 +54,10 @@ describe('Toast', () => {
     })
   })
 
-  it('Renders X as a close button when onClose is passed', () => {
+  it('Renders X as a close button when onClose is passed', async () => {
     const closeToast = jest.fn()
 
-    const wrapper = mount(<Toast type="success" content={content} closeToast={closeToast} />)
+    const wrapper = await mountAndCheckA11Y(<Toast type="success" content={content} closeToast={closeToast} />)
 
     expect(wrapper.findDataTest('toast-close').exists()).toBeTruthy()
     expect(closeToast).toBeCalledTimes(0)


### PR DESCRIPTION
Bunch of my components are written using `mount` instead of proper `mountAndCheckA11Y`. This PR fixes the problem. I didn't amend `Tooltip` for obvious reasons.