### PR TITLE
Add default button type

### DIFF
--- a/packages/ui/__tests__/Button.test.tsx
+++ b/packages/ui/__tests__/Button.test.tsx
@@ -141,6 +141,7 @@ describe('Button', () => {
     expect(props).toHaveProperty('onClick', onClick)
     expect(props).toHaveProperty('rel', 'noopener noreferrer')
     expect(props).toHaveProperty('target', '_blank')
+    expect(props).toHaveProperty('type', undefined)
   })
 
   it('Renders button with a default button semantics, link specific params are undefined', async () => {
@@ -149,6 +150,7 @@ describe('Button', () => {
     const props = wrapper.find('button').props()
     expect(props).toHaveProperty('rel', undefined)
     expect(props).toHaveProperty('target', undefined)
+    expect(props).toHaveProperty('type', 'button')
   })
 
   it('Renders button with a link semantics, check that noopener attribute is passed to a link by default', async () => {

--- a/packages/ui/src/Button.tsx
+++ b/packages/ui/src/Button.tsx
@@ -74,6 +74,7 @@ type ButtonTypeProps =
       href: string
       target?: LinkTarget
       rel?: LinkRel | LinkRel[]
+      type?: never
     } & ButtonNotDisabledProps)
   | ({
       component?: 'button'
@@ -131,6 +132,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
       iconRightClassName,
       rel = 'noopener',
       target,
+      type = 'button',
       ...rest
     },
     ref,
@@ -161,6 +163,7 @@ export const Button = forwardRef<HTMLElement, ButtonProps>(
             disabled={disabled}
             rel={Component === 'a' ? relFinal : undefined}
             target={Component === 'a' ? target : undefined}
+            type={Component === 'button' ? type : undefined}
             {...rest}
           >
             <span className={styles.outline} />

--- a/packages/ui/src/IconButton.tsx
+++ b/packages/ui/src/IconButton.tsx
@@ -25,6 +25,7 @@ export const IconButton: FC<IconButtonProps> = ({
   ariaHidden,
   ariaLabelledBy,
   ariaLabel,
+  type = 'button',
   ...rest
 }) => (
   <button
@@ -39,6 +40,7 @@ export const IconButton: FC<IconButtonProps> = ({
     aria-hidden={ariaHidden}
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledBy}
+    type={type}
     {...rest}
   >
     <span className={styles.outline} />


### PR DESCRIPTION
Closes #130

@jvorcak I would say that 90% of our buttons are of `button` type. So I would not require the `type` property, but rather have a sane default.WDYT?