### PR TITLE
Fix `validate` typings

### DIFF
--- a/packages/ui/src/SelectFieldFormik.tsx
+++ b/packages/ui/src/SelectFieldFormik.tsx
@@ -10,12 +10,12 @@ export type SelectFieldFormikProps<V extends object, OV = string> = SelectFieldE
     | {
         name: ExtractKeysOfValueType<V, SelectFieldOption<OV> | null>
         isClearable: true
-        validate?: FieldValidatorGeneric<V[keyof V]>
+        validate?: FieldValidatorGeneric<SelectFieldOption<OV> | null>
       }
     | {
         name: ExtractKeysOfValueType<V, SelectFieldOption<OV>>
         isClearable?: false
-        validate?: FieldValidatorGeneric<V[keyof V]>
+        validate?: FieldValidatorGeneric<SelectFieldOption<OV>>
       }
   )
 

--- a/packages/ui/src/TextFieldFormik.tsx
+++ b/packages/ui/src/TextFieldFormik.tsx
@@ -7,7 +7,7 @@ import { ExtractKeysOfValueType } from './utils/types'
 
 export type TextFieldFormikProps<V extends object> = TextFieldExtraProps<Exclude<TextFieldTypes, 'number' | 'password'>> & {
   name: ExtractKeysOfValueType<V, string | undefined>
-  validate?: FieldValidatorGeneric<V[keyof V]>
+  validate?: FieldValidatorGeneric<string | undefined>
 }
 
 export const TextFieldFormik = <V extends object>({ type, name, validate, ...props }: TextFieldFormikProps<V>): ReactElement => {


### PR DESCRIPTION
It is pretty much the opposite of https://github.com/hazelcast/frontend-shared/pull/154
The problem with `V[keyof V]` is that it resolves to a union type of all possible form values.

Example:

```ts
type FormValues = {
  name: string
  isJedi: boolean
}
```

In this case, `V[keyof V]` resolves to `string | boolean` and `validate` for the `name` `TextField` is mistakenly required to handle not only `string`, but `boolean` as well.