### PR TITLE
Update wrapper after act

### DIFF
--- a/packages/test-helpers/src/enzyme.ts
+++ b/packages/test-helpers/src/enzyme.ts
@@ -46,12 +46,14 @@ export const mountAndCheckA11Y = async <P>(
   if (actOption === 'sync') {
     act(() => {
       wrapper = mountEnzyme(node, mountOptions)
+      wrapper.update()
     })
   } else if (actOption === 'async') {
     // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       wrapper = mountEnzyme(node, mountOptions)
     })
+    wrapper.update()
   } else {
     wrapper = mountEnzyme(node, mountOptions)
   }


### PR DESCRIPTION
Potenatially, something could have changed the layout inside of act (like an effect). We need to update the wrapper to return the updated component.