### PR TITLE
fix: react-use imports and remove use-deep-compare

### DIFF
--- a/packages/ui/src/Alert.tsx
+++ b/packages/ui/src/Alert.tsx
@@ -4,7 +4,7 @@ import { ChevronRight, X } from 'react-feather'
 
 import { PartialRequired } from '@hazelcast/helpers'
 
-import { useKey } from 'react-use'
+import useKey from 'react-use/lib/useKey'
 import { escKeyFilterPredicate } from './utils/keyboard'
 import { Link, LinkProps } from './Link'
 import { Button, ButtonAccessibleIconLeftProps } from './Button'

--- a/packages/ui/src/Pagination.tsx
+++ b/packages/ui/src/Pagination.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useCallback, useMemo, useRef, useState } from 'react'
-import { useDeepCompareMemo } from 'use-deep-compare'
+import { useDeepCompareMemo } from './hooks/useDeepCompareMemo'
 import { Form, Formik } from 'formik'
 import { ChevronLeft, ChevronRight, Settings, ArrowLeft } from 'react-feather'
 import cn from 'classnames'

--- a/packages/ui/src/Toast.tsx
+++ b/packages/ui/src/Toast.tsx
@@ -2,7 +2,7 @@ import React, { FC, ReactNode, useCallback } from 'react'
 import cn from 'classnames'
 import { AlertTriangle, CheckCircle, AlertCircle, Info, Icon as IconType, X } from 'react-feather'
 
-import { useKey } from 'react-use'
+import useKey from 'react-use/lib/useKey'
 import { escKeyFilterPredicate } from './utils/keyboard'
 import { IconButton } from './IconButton'
 import { Icon } from './Icon'

--- a/packages/ui/src/hooks/useDeepCompareMemo.ts
+++ b/packages/ui/src/hooks/useDeepCompareMemo.ts
@@ -1,0 +1,8 @@
+import { DependencyList, useMemo } from 'react'
+
+import { useDeepEqual } from './useDeepEqual'
+
+export const useDeepCompareMemo = <T>(fn: () => T, deps: DependencyList) => {
+  const depsMemoized = useDeepEqual(deps, [])
+  return useMemo(fn, depsMemoized)
+}

--- a/packages/ui/src/hooks/useDeepEqual.ts
+++ b/packages/ui/src/hooks/useDeepEqual.ts
@@ -1,0 +1,12 @@
+import { useRef } from 'react'
+import deepEqual from 'dequal'
+
+export const useDeepEqual = <T>(value: T, defaultValue: T) => {
+  const ref = useRef(defaultValue)
+
+  if (!deepEqual(ref.current, value)) {
+    ref.current = value
+  }
+
+  return ref.current
+}

--- a/packages/ui/src/hooks/useDimensions.ts
+++ b/packages/ui/src/hooks/useDimensions.ts
@@ -1,5 +1,5 @@
 import { RefObject, useCallback, useEffect, useState } from 'react'
-import { useEvent } from 'react-use'
+import useEvent from 'react-use/lib/useEvent'
 
 export type Dimensions = {
   width: number


### PR DESCRIPTION
Fixes the IE11 (storybook) crashes

- Corrects imports of `react-use`
- Replaces `use-deep-compare/useDeepCompareMemo` with custom `useDeepCompareMemo` fn.