### PR TITLE
Fixes selectbox zIndex with menuPortalTarget=self

### DIFF
--- a/packages/ui/src/SelectField.module.scss
+++ b/packages/ui/src/SelectField.module.scss
@@ -166,6 +166,7 @@ $select: ':global .hz-select-field__control';
     background-color: c.$colorNeutralLighter;
     overflow: hidden;
     box-shadow: 0 c.$selectMenuShadowSize c.$selectMenuShadowBlur 0 c.$colorShadow;
+    z-index: c.$zIndex1000;
 
     @include c.typographyBodySmall;
 


### PR DESCRIPTION
Before:

<img width="958" alt="Screenshot 2021-03-05 at 12 42 12" src="https://user-images.githubusercontent.com/1083817/110111350-7a081c00-7db0-11eb-9eee-d4f8885b1989.png">

After: 
<img width="957" alt="Screenshot 2021-03-05 at 12 42 28" src="https://user-images.githubusercontent.com/1083817/110111345-783e5880-7db0-11eb-9a5d-a6fbd097deb9.png">

This shouldn't break anything I guess