### PR TITLE
update(Alert): fix issue with empty array as actions

### DIFF
--- a/packages/ui/__tests__/Alert.test.tsx
+++ b/packages/ui/__tests__/Alert.test.tsx
@@ -136,6 +136,12 @@ describe('Alert', () => {
       })
   })
 
+  it('Renders only text content with an empty array passed as "actions" property', async () => {
+    const wrapper = await mountAndCheckA11Y(<Alert type="success" title={title} content={content} closeToast={noOp} actions={[]} />)
+    const textContent = wrapper.findDataTest('alert-body').text()
+    expect(textContent).toBe(content)
+  })
+
   it('Alert.closeToast called after simulating Escape key', async () => {
     const closeToast = jest.fn()
 

--- a/packages/ui/src/Alert.tsx
+++ b/packages/ui/src/Alert.tsx
@@ -90,7 +90,7 @@ export const Alert: FC<AlertProps> = ({ type, title, content, actions, className
       </div>
       <div data-test="alert-body" className={styles.body}>
         <div data-test="alert-content">{content}</div>
-        {actions?.length && (
+        {actions?.length ? (
           <div data-test="alert-actions" className={styles.actions}>
             {actions.map((action, aI) => {
               if (isAlertActionButton(action)) {
@@ -137,7 +137,7 @@ export const Alert: FC<AlertProps> = ({ type, title, content, actions, className
               )
             })}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes the following issue:
if you pass an empty array as the "actions" property of the `<Alert />` component, the component renders a "0" (aka `actions.length`) after the content.