### PR TITLE
Fix: make helperText props dependent on Help props

### DIFF
--- a/packages/ui/src/Checkbox.tsx
+++ b/packages/ui/src/Checkbox.tsx
@@ -5,7 +5,7 @@ import { useUID } from 'react-uid'
 import classNames from 'classnames'
 
 import { Error, errorId } from './Error'
-import { Help, helpTooltipId } from './Help'
+import { Help, HelpProps, helpTooltipId } from './Help'
 
 import styles from './Checkbox.module.scss'
 
@@ -20,7 +20,7 @@ type CheckboxCoreProps = {
 
 export type CheckboxExtraProps = {
   label: React.ReactNode
-  helperText?: string
+  helperText?: HelpProps['helperText']
   indeterminate?: boolean
   disabled?: boolean
   required?: boolean

--- a/packages/ui/src/NumberField.tsx
+++ b/packages/ui/src/NumberField.tsx
@@ -6,9 +6,9 @@ import cn from 'classnames'
 
 import { TextField } from './TextField'
 import { IconButton, IconButtonDisabledProps, IconButtonNotDisabledProps } from './IconButton'
+import { HelpProps } from './Help'
 
 import styles from './NumberField.module.scss'
-import { HelpProps } from './Help'
 
 type NumberFieldCoreProps = {
   name: string

--- a/packages/ui/src/NumberField.tsx
+++ b/packages/ui/src/NumberField.tsx
@@ -1,5 +1,5 @@
 import { DataTestProp } from '@hazelcast/helpers'
-import React, { FC, FocusEvent, ChangeEvent, ReactElement, InputHTMLAttributes, useCallback, useMemo } from 'react'
+import React, { FC, FocusEvent, ChangeEvent, InputHTMLAttributes, useCallback, useMemo } from 'react'
 import { Plus, Minus } from 'react-feather'
 import useIsomorphicLayoutEffect from 'react-use/lib/useIsomorphicLayoutEffect'
 import cn from 'classnames'
@@ -8,6 +8,7 @@ import { TextField } from './TextField'
 import { IconButton, IconButtonDisabledProps, IconButtonNotDisabledProps } from './IconButton'
 
 import styles from './NumberField.module.scss'
+import { HelpProps } from './Help'
 
 type NumberFieldCoreProps = {
   name: string
@@ -26,7 +27,7 @@ export type NumberFieldExtraProps = {
   defaultValue?: number
   numberType?: 'int' | 'float'
   label: string
-  helperText?: string | ReactElement
+  helperText?: HelpProps['helperText']
   className?: string
   labelClassName?: string
   inputClassName?: string

--- a/packages/ui/src/PasswordField.tsx
+++ b/packages/ui/src/PasswordField.tsx
@@ -3,7 +3,6 @@ import React, {
   FC,
   FocusEvent,
   ChangeEvent,
-  ReactElement,
   InputHTMLAttributes,
   useMemo,
   useState,
@@ -16,6 +15,7 @@ import { Eye, EyeOff, Lock } from 'react-feather'
 
 import { TextField } from './TextField'
 import { IconButton, IconButtonDisabledProps, IconButtonNotDisabledProps } from './IconButton'
+import { HelpProps } from './Help'
 
 import styles from './PasswordField.module.scss'
 
@@ -30,7 +30,7 @@ export type PasswordFieldExtraProps = {
   showIconLabel?: string
   hideIconLabel?: string
   label: string
-  helperText?: string | ReactElement
+  helperText?: HelpProps['helperText']
   labelClassName?: string
   className?: string
   inputClassName?: string

--- a/packages/ui/src/Radio.tsx
+++ b/packages/ui/src/Radio.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { DataTestProp } from '@hazelcast/helpers'
 import { useUID } from 'react-uid'
 
-import { Help, helpTooltipId } from './Help'
+import { Help, HelpProps, helpTooltipId } from './Help'
 import { RadioGroupContext } from './RadioGroupContext'
 
 import styles from './Radio.module.scss'
@@ -16,7 +16,7 @@ type RadioCoreProps = {
 
 export type RadioExtraProps = {
   label: string
-  helperText?: string
+  helperText?: HelpProps['helperText']
   disabled?: boolean
   required?: boolean
   className?: string

--- a/packages/ui/src/SelectField.tsx
+++ b/packages/ui/src/SelectField.tsx
@@ -9,7 +9,7 @@ import { useUID } from 'react-uid'
 
 import { Error, errorId } from './Error'
 import { Label } from './Label'
-import { Help } from './Help'
+import { Help, HelpProps } from './Help'
 import { Icon } from './Icon'
 import { IconButton } from './IconButton'
 import { canUseDOM } from './utils/ssr'
@@ -139,7 +139,7 @@ export type SelectFieldExtraProps<V> = {
   isClearable?: boolean
   options: SelectFieldOption<V>[]
   label: string
-  helperText?: string | ReactElement
+  helperText?: HelpProps['helperText']
   className?: string
   labelClassName?: string
   errorClassName?: string

--- a/packages/ui/src/TextArea.tsx
+++ b/packages/ui/src/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC, FocusEvent, ReactElement, useRef } from 'react'
+import React, { ChangeEvent, FC, FocusEvent, useRef } from 'react'
 import cn from 'classnames'
 import useResizeAware from 'react-resize-aware'
 import { DataTestProp } from '@hazelcast/helpers'
@@ -6,7 +6,7 @@ import useIsomorphicLayoutEffect from 'react-use/lib/useIsomorphicLayoutEffect'
 import { useUID } from 'react-uid'
 
 import { Error, errorId } from './Error'
-import { Help } from './Help'
+import { Help, HelpProps } from './Help'
 import { Label } from './Label'
 import { PopperRef } from './Tooltip'
 
@@ -26,7 +26,7 @@ export type TextAreaExtraProps = {
   textareaClassName?: string
   errorClassName?: string
   resizable?: boolean
-  helperText?: string | ReactElement
+  helperText?: HelpProps['helperText']
 } & Partial<Pick<HTMLTextAreaElement, 'className' | 'disabled' | 'placeholder' | 'required' | 'rows'>>
 
 export type TextAreaProps = TextAreaCoreProps & TextAreaExtraProps & DataTestProp

--- a/packages/ui/src/TextField.tsx
+++ b/packages/ui/src/TextField.tsx
@@ -8,7 +8,7 @@ import { useUID } from 'react-uid'
 import { Icon } from './Icon'
 import { Label } from './Label'
 import { Error, errorId } from './Error'
-import { Help, helpTooltipId } from './Help'
+import { Help, HelpProps, helpTooltipId } from './Help'
 
 import styles from './TextField.module.scss'
 
@@ -35,7 +35,7 @@ type TextFieldCoreProps<T extends TextFieldTypes> = {
 }
 export type TextFieldExtraProps<T extends TextFieldTypes> = {
   label: string
-  helperText?: string | ReactElement
+  helperText?: HelpProps['helperText']
   className?: string
   labelClassName?: string
   inputContainerClassName?: string

--- a/packages/ui/src/Toggle.tsx
+++ b/packages/ui/src/Toggle.tsx
@@ -4,7 +4,7 @@ import { useUID } from 'react-uid'
 import { DataTestProp } from '@hazelcast/helpers'
 
 import { Error, errorId } from './Error'
-import { Help, helpTooltipId } from './Help'
+import { Help, HelpProps, helpTooltipId } from './Help'
 
 import styles from './Toggle.module.scss'
 
@@ -19,7 +19,7 @@ type ToggleCoreProps = {
 
 export type ToggleExtraProps = {
   label: string | React.ReactNode
-  helperText?: string
+  helperText?: HelpProps['helperText']
   disabled?: boolean
   className?: string
   classNameLabel?: string


### PR DESCRIPTION
Some fields' `helperText` prop accepted only `string`. This PR makes fields' prop `helperText` same as `Help`'s `helperText` prop.