### PR TITLE
update(datepicker): remove react-datepicker from peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,16 @@ However, Next.js still [forbids](https://github.com/vercel/next.js/blob/master/e
 So please make sure to import the following global styles in your projects if you need them.
 
 ```typescript
-import 'react-datepicker/dist/react-datepicker.css'
+import '@hazelcast/ui/styles/datepicker.scss'
 ```
+
+or
+
+```typescript
+import '@hazelcast/ui/styles/datepicker.module.scss'
+```
+
+if you need a CSS modules version
 
 ## SSR
 

--- a/packages/ui/.storybook/preview.scss
+++ b/packages/ui/.storybook/preview.scss
@@ -1,5 +1,6 @@
 @use '../styles/fonts';
 @use '../styles/constants' as c;
+@use '../styles/datepicker/datepicker.module';
 
 $screenMinWidth: 1280px;
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
     "dequal": "^2.0.2",
     "formik": "^2.2.0",
     "rc-tooltip": "^4.2.3",
+    "react-datepicker": "^3.4.1",
     "react-feather": "^2.0.8",
     "react-merge-refs": "^1.1.0",
     "react-modal": "^3.12.1",
@@ -88,7 +89,6 @@
     "postcss-reporter": "^7.0.1",
     "postcss-scss": "^3.0.2",
     "react": "^16.14.0",
-    "react-datepicker": "^3.4.1",
     "react-dom": "^16.14.0",
     "storybook-addon-designs": "^5.4.2",
     "stylelint": "^13.7.2",
@@ -99,7 +99,6 @@
   },
   "peerDependencies": {
     "react": "^16.14.0",
-    "react-datepicker": "^3.4.1",
     "react-dom": "^16.14.0"
   }
 }

--- a/packages/ui/styles/datepicker/datepicker.module.scss
+++ b/packages/ui/styles/datepicker/datepicker.module.scss
@@ -1,0 +1,1 @@
+@use 'react-datepicker/dist/react-datepicker.module';

--- a/packages/ui/styles/datepicker/datepicker.scss
+++ b/packages/ui/styles/datepicker/datepicker.scss
@@ -1,0 +1,1 @@
+@use 'react-datepicker/dist/react-datepicker';


### PR DESCRIPTION
In my opinion, the additional peer dependency makes the lib less flexible and will make future upgrades more difficult.
This is a suggestion on how to omit it.