### PR TITLE
Feat: add 'closable' option to Dialog props

### DIFF
--- a/packages/ui/src/Dialog.tsx
+++ b/packages/ui/src/Dialog.tsx
@@ -28,7 +28,7 @@ export type DialogProps = {
   affirmation?: string
   consequences: ReactNode
 } & DialogActionProps &
-  Pick<ModalProps, 'isOpen' | 'onClose' | 'parentSelector' | 'portalClassName'>
+  Pick<ModalProps, 'isOpen' | 'onClose' | 'closable' | 'parentSelector' | 'portalClassName'>
 
 /**
  * ### Purpose
@@ -79,7 +79,7 @@ export const Dialog: FC<DialogProps> = ({
       footerClassName={styles.dialogFooter}
       actions={actions}
       title={affirmation}
-      closable={false}
+      showCloseButton={false}
       {...rest}
     >
       {consequences}

--- a/packages/ui/src/Modal.tsx
+++ b/packages/ui/src/Modal.tsx
@@ -24,6 +24,7 @@ export type ModalProps = {
   autoFocus?: boolean
   children?: ReactNode
   closable?: boolean
+  showCloseButton?: boolean
   bodyClassName?: string
   headerClassName?: string
   contentClassName?: string
@@ -55,6 +56,7 @@ export const Modal: FC<ModalProps> = ({
   children,
   className,
   closable = true,
+  showCloseButton = true,
   bodyClassName,
   headerClassName,
   contentClassName,
@@ -89,8 +91,8 @@ export const Modal: FC<ModalProps> = ({
           <h3 data-test="modal-header-title" className={styles.title}>
             {title}
           </h3>
-          {closable && (
-            // Note: Dialog use-case. "Not closable" modal can only be closed via "Cancel" button.
+          {closable && showCloseButton && (
+            // Note: Mostly a Dialog use-case. We want it to be closable but we don't want to show an X button in the corner.
             <div className={styles.close}>
               <IconButton data-test="modal-button-close" kind="transparent" ariaLabel="Close icon" icon={X} onClick={onClose} />
             </div>


### PR DESCRIPTION
It is now possible to close the Dialog with Esc key.